### PR TITLE
Treat notes with velocity of zero as off

### DIFF
--- a/lib/hooks/use-midi-notes.ts
+++ b/lib/hooks/use-midi-notes.ts
@@ -32,7 +32,7 @@ export const useMIDINotes = (filter: MIDINoteFilter = {}) => {
       if (value === notes[notes.length - 1]) {
         return
       }
-      if (value.on) {
+      if (value.on && value.velocity !== 0) {
         setNotes([...notes, value])
       } else {
         setNotes(notes.filter((n) => n.note !== value.note))


### PR DESCRIPTION
See this issue for more details
https://github.com/nicorobo/react-midi-hooks/issues/20

TL;DR: some midi instruments send a "note on" message with velocity zero instead of "note off" messages. Prior to this change, the `useMidiNotes` hook would never remove notes from the list when using these instruments. Now those instruments work like other ones.